### PR TITLE
Proxy methods for bindWithDelay/onBind

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
 		<link rel="stylesheet" type="text/css" media="screen, projection" href="demo/styles.css" />
 
 		<script type='text/javascript' src='demo/jquery-1.9.1.js'></script>
-		<script type='text/javascript' src='bindWithDelay.js'></script>
 		<script type='text/javascript' src='onDelay.js'></script>
 
 		<script type='text/javascript'>
@@ -46,22 +45,22 @@
 			}
 
 			$(function() {
-				$(window).bind("resize", {when:'instant'}, updateResize);
-				$(window).bindWithDelay("resize", {when:'delay'}, updateResize, 1000);
-				$(window).bindWithDelay("resize", {when:'throttle'}, updateResize, 1000, true);
+				$(window).on("resize", {when:'instant'}, updateResize);
+				$(window).onDelay("resize", {when:'delay'}, updateResize, 1000);
+				$(window).onDelay("resize", {when:'throttle'}, updateResize, 1000, true);
 
 				$(document).on("mousemove", {when:'instant'}, updateResize);
 				$(document).onDelay("mousemove", {when:'delay'}, updateResize, 1000);
 				$(window).onDelay("mousemove", {when:'throttle'}, updateResize, 1000, true);
 				$(window).onDelay("mousemove", function() {}, 1000, true);
 
-				$(document).bind("click", {when:'instant'}, updateResize);
-				$(document).bindWithDelay("click", {when:'delay'}, updateResize, 1000);
-				$(window).bindWithDelay("click", {when:'throttle'}, updateResize, 1000, true);
+				$(document).on("click", {when:'instant'}, updateResize);
+				$(document).onDelay("click", {when:'delay'}, updateResize, 1000);
+				$(window).onDelay("click", {when:'throttle'}, updateResize, 1000, true);
 
-				$(document).bind("scroll", {when:'instant'}, updateResize);
-				$(document).bindWithDelay("scroll", {when:'delay'}, updateResize, 1000);
-				$(window).bindWithDelay("scroll", {when:'throttle'}, updateResize, 1000, true);
+				$(document).on("scroll", {when:'instant'}, updateResize);
+				$(document).onDelay("scroll", {when:'delay'}, updateResize, 1000);
+				$(window).onDelay("scroll", {when:'throttle'}, updateResize, 1000, true);
 
 			});
 		</script>

--- a/onDelay.js
+++ b/onDelay.js
@@ -52,4 +52,8 @@ $.fn.onDelay = function(events, selector, data, handler, timeout, throttle) {
     });
 };
 
+$.fn.onBind = $.fn.bindWithDelay = function(events, data, handler, timeout, throttle) {
+	return $(this).onDelay(events, data, handler, timeout, throttle);
+};
+
 })(jQuery);

--- a/onDelay.js
+++ b/onDelay.js
@@ -52,8 +52,4 @@ $.fn.onDelay = function(events, selector, data, handler, timeout, throttle) {
     });
 };
 
-$.fn.onBind = $.fn.bindWithDelay = function(events, data, handler, timeout, throttle) {
-	return $(this).onDelay(events, data, handler, timeout, throttle);
-};
-
 })(jQuery);

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <title>onDelay() QUnit test</title>
+		<link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-git.css"/>
+		<script src="http://code.jquery.com/qunit/qunit-git.js"></script>
+		<script type="text/javascript" src="../demo/jquery-1.9.1.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+
+		<script src="../onDelay.js"></script>
+
+		<script src="onDelay.js"></script>
+	</body>
+</html>

--- a/test/onDelay.js
+++ b/test/onDelay.js
@@ -1,0 +1,18 @@
+module('onDelay');
+
+asyncTest("delay", function() {
+	var count		= 0;
+
+	expect(2);
+	
+	jQuery(document).onDelay("foo", function() { ++count; }, 50);
+
+	equal(count, 0, "Not incremented yet");
+
+	jQuery(document).trigger("foo").trigger("foo").trigger("foo");
+
+	setTimeout(function() {
+		equal(count, 1, "Three triggers, one count");
+		start();
+	}, 100);
+});


### PR DESCRIPTION
Minimalist proxy methods for `bindWithDelay`/`onBind`.

You could still be backwards compatible if both proxy methods were aliasses of `onDelay`; any existing code should still work as is, but you could now add a selector like `onDelay`.

Also adjusted the index.html to use only onDelay; seems to work fine, but I'll look into qunit as you suggested.
